### PR TITLE
Add Next.js site with GitHub Pages workflow

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,24 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+      - run: npm ci
+      - run: npm run build
+      - uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./out
+          publish_branch: gh-pages

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+.next
+out
+.DS_Store
+npm-debug.log*

--- a/README.md
+++ b/README.md
@@ -1,1 +1,22 @@
 # yak-shaver.com
+
+This repository contains a simple Next.js site that is exported as a static site and deployed to GitHub Pages via GitHub Actions.
+
+## Local development
+
+```bash
+npm install
+npm run dev
+```
+
+## Build & Export
+
+```bash
+npm run build
+```
+
+The static output will be in the `out/` directory.
+
+## Deployment
+
+GitHub Actions will build and publish the `out/` directory to the `gh-pages` branch, which is used by GitHub Pages.

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,8 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  output: 'export',
+  images: { unoptimized: true },
+  trailingSlash: true,
+};
+
+module.exports = nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "yak-shaver.com",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build && next export",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "^14.1.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  }
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,0 +1,8 @@
+export default function Home() {
+  return (
+    <main>
+      <h1>Welcome to yak-shaver.com!</h1>
+      <p>This site is powered by Next.js and deployed to GitHub Pages.</p>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- set up a basic Next.js site with static export
- add GitHub Actions workflow to publish to GitHub Pages
- document how to run and deploy the site

## Testing
- `git status --short`
