### PR TITLE
Add terminal interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # yak-shaver.com
 
-This repository contains a simple static site built with Vite, React and TypeScript. The site is deployed to GitHub Pages using GitHub Actions.
+This repository contains a simple static site built with Vite, React and TypeScript. The site features an interactive terminal powered by the open source **react-console-emulator** library. The static output is deployed to GitHub Pages using GitHub Actions.
 
 ## Local development
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   },
   "dependencies": {
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "react-console-emulator": "^1.4.0"
   },
   "devDependencies": {
     "@types/react": "^18.2.7",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,7 @@
+import Terminal from './Terminal';
+
 function App() {
-  return (
-    <main>
-      <h1>Welcome to yak-shaver.com!</h1>
-      <p>This site is powered by Vite, React and TypeScript and deployed to GitHub Pages.</p>
-    </main>
-  );
+  return <Terminal />;
 }
 
 export default App;

--- a/src/Terminal.tsx
+++ b/src/Terminal.tsx
@@ -1,0 +1,32 @@
+import ReactConsole from 'react-console-emulator';
+import './terminal.css';
+
+const commands = {
+  help: {
+    description: 'List available commands',
+    usage: 'help',
+    fn: () => 'Available commands: ls, help, owner',
+  },
+  ls: {
+    description: 'List site files',
+    usage: 'ls',
+    fn: () => 'index.html  about.html',
+  },
+  owner: {
+    description: 'Show site owner',
+    usage: 'owner',
+    fn: () => 'This site is owned by Yak Shaver.',
+  },
+};
+
+export default function Terminal() {
+  return (
+    <div className="terminal-container">
+      <ReactConsole
+        commands={commands}
+        promptLabel="$"
+        autoFocus
+      />
+    </div>
+  );
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
-import './index.css';
+import './terminal.css';
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>

--- a/src/terminal.css
+++ b/src/terminal.css
@@ -1,0 +1,48 @@
+body {
+  background-color: #000;
+  color: #0f0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+  margin: 0;
+  font-family: monospace;
+}
+
+.terminal-container {
+  background-color: #000;
+  color: #0f0;
+  padding: 1rem;
+  width: 80%;
+  max-width: 600px;
+  box-sizing: border-box;
+}
+
+.terminal-output {
+  white-space: pre-wrap;
+  margin-bottom: 0.5rem;
+}
+
+.terminal-line {
+  margin-bottom: 0.25rem;
+}
+
+.terminal-response {
+  margin-left: 1rem;
+}
+
+.terminal-input-line {
+  display: flex;
+}
+
+.terminal-input {
+  background: transparent;
+  border: none;
+  color: #0f0;
+  outline: none;
+  flex: 1;
+}
+
+.terminal-prompt {
+  margin-right: 0.5rem;
+}


### PR DESCRIPTION
## Summary
- implement simple terminal-style interface
- style terminal with black background and green text
- replace custom terminal with OSS `react-console-emulator`

## Testing
- `npm run build` *(fails to find module 'react-console-emulator')*