### PR TITLE
Add demo playback and shell commands

### DIFF
--- a/src/Terminal.tsx
+++ b/src/Terminal.tsx
@@ -20,31 +20,51 @@ export default function Terminal() {
     }
 
     let command = '';
+    let inDemo = true;
     const prompt = () => {
-      term.write('\r\n$ ');
+      term.write('\r\n> ');
+    };
+
+    const sleep = (ms: number) => new Promise((res) => setTimeout(res, ms));
+
+    const typeText = async (text: string, delay = 50) => {
+      for (const ch of text) {
+        term.write(ch);
+        await sleep(delay);
+      }
     };
 
     const executeCommand = (cmd: string) => {
       switch (cmd) {
         case 'help':
-          term.writeln('Available commands: ls, help, owner');
+          term.writeln('Available commands: help, about');
           break;
-        case 'ls':
-          term.writeln('index.html  about.html');
-          break;
-        case 'owner':
-          term.writeln('This site is owned by Yak Shaver.');
+        case 'about':
+          term.writeln('This is a demo terminal built with React and xterm.js.');
           break;
         case '':
           break;
         default:
-          term.writeln(`Unknown command: ${cmd}`);
+          term.writeln(`Command not found: ${cmd}`);
       }
     };
 
-    prompt();
+    const runDemo = async () => {
+      await typeText('Welcome to the Demo Terminal!\r\n');
+      await sleep(500);
+      term.write('> ');
+      await typeText('help');
+      await sleep(300);
+      term.write('\r\n');
+      executeCommand('help');
+      prompt();
+      inDemo = false;
+    };
+
+    void runDemo();
 
     term.onData((data) => {
+      if (inDemo) return;
       const code = data.charCodeAt(0);
       if (code === 13) {
         executeCommand(command.trim());


### PR DESCRIPTION
## Summary
- implement typewriter demo and command prompt
- support `help` and `about` commands with fallback message
- start interactive mode after demo

## Testing
- `npm run build` *(fails: Cannot find module 'react' etc.)*
